### PR TITLE
add search+top100, cleanup

### DIFF
--- a/app/src/main/graphql/com/android/aniview_kun/MediaListQuery.graphql
+++ b/app/src/main/graphql/com/android/aniview_kun/MediaListQuery.graphql
@@ -1,5 +1,5 @@
-query MediaListQuery($status: MediaStatus, $type: MediaType!, $sort: [MediaSort]!) {
-    Page {
+query MediaListQuery($status: MediaStatus, $type: MediaType, $sort: [MediaSort], $page: Int, $perPage: Int, $search: String) {
+    Page (page: $page, perPage: $perPage) {
         pageInfo {
             total
             currentPage
@@ -7,7 +7,7 @@ query MediaListQuery($status: MediaStatus, $type: MediaType!, $sort: [MediaSort]
             hasNextPage
             perPage
         }
-        media (status: $status, type: $type, sort: $sort) {
+        media (status: $status, type: $type, sort: $sort, search: $search) {
             id
             title {
                 romaji

--- a/app/src/main/graphql/com/android/aniview_kun/schema.sdl
+++ b/app/src/main/graphql/com/android/aniview_kun/schema.sdl
@@ -9,7 +9,7 @@ enum CacheControlScope {
 
 type Page {
     pageInfo: PageInfo
-    media(status: MediaStatus, type: MediaType, sort: [MediaSort]): [Media]
+    media(status: MediaStatus, type: MediaType, sort: [MediaSort], search: String): [Media]
 }
 
 enum MediaSort {
@@ -363,7 +363,7 @@ type FuzzyDate {
 }
 
 type Query {
-    Page: Page
+    Page(page: Int, perPage: Int): Page
     Media: Media
     Title: Title
 }

--- a/app/src/main/java/com/android/aniviewer_kun/MainActivity.kt
+++ b/app/src/main/java/com/android/aniviewer_kun/MainActivity.kt
@@ -34,7 +34,9 @@ class MainActivity : AppCompatActivity() {
         // menu should be considered as top level destinations.
         appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.nav_airing
+                R.id.nav_airing,
+                R.id.nav_top100,
+                R.id.nav_search
             ), drawerLayout
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
@@ -48,6 +50,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onSupportNavigateUp(): Boolean {
+        println("onSupportNavigateUp")
         val navController = findNavController(R.id.nav_host_fragment_content_main)
         return navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
     }

--- a/app/src/main/java/com/android/aniviewer_kun/MainViewModel.kt
+++ b/app/src/main/java/com/android/aniviewer_kun/MainViewModel.kt
@@ -23,13 +23,21 @@ class MainViewModel: ViewModel() {
     var fetchDone : MutableLiveData<Boolean> = MutableLiveData(false)
 
     private var media = MutableLiveData<List<MediaListQuery.Medium?>?>()
+    private var searchMediaResults = MutableLiveData<List<MediaListQuery.Medium?>?>()
 
-    fun getMediaListByStatus(status: Optional<MediaStatus?>, type: MediaType, sort: List<MediaSort>) {
+    fun getMediaListByStatus(status: MediaStatus, type: MediaType, sort: List<MediaSort>, currentPage: Int, perPage: Int) {
         viewModelScope.launch(
         context = viewModelScope.coroutineContext
             + Dispatchers.IO) {
             try {
-                val page = repository.getMediaByStatus(status, type, sort)
+                val page = repository.getMediaList(
+                    Optional.present(status),
+                    Optional.present(type),
+                    Optional.present(sort),
+                    Optional.present(currentPage),
+                    Optional.present(perPage),
+                    Optional.absent()
+                )
                 media.postValue(page?.media)
             } catch (e: ApolloException) {
                 println("Error fetching media: $e")
@@ -37,8 +45,67 @@ class MainViewModel: ViewModel() {
         }
     }
 
+    fun searchMedia(search: String, perPage: Int) {
+        viewModelScope.launch(
+            context = viewModelScope.coroutineContext
+                    + Dispatchers.IO) {
+            try {
+                val page = repository.getMediaList(
+                    Optional.absent(),
+                    Optional.Present(MediaType.ANIME),
+                    Optional.present(listOf(MediaSort.POPULARITY_DESC)),
+                    Optional.absent(),
+                    Optional.present(perPage),
+                    Optional.present(search)
+                )
+                searchMediaResults.postValue(page?.media)
+            } catch (e: ApolloException) {
+                println("Error fetching media: $e")
+            }
+        }
+    }
+
+    fun getTop100Media(type: MediaType, sort:  List<MediaSort>) {
+        viewModelScope.launch(
+            context = viewModelScope.coroutineContext
+                    + Dispatchers.IO) {
+            try {
+                val mediaList = repository.getMediaList(
+                    Optional.absent(),
+                    Optional.present(type),
+                    Optional.present(sort),
+                    Optional.present(1),
+                    Optional.absent(),
+                    Optional.absent()
+                )?.media?.toMutableList()
+                val page2Media = repository.getMediaList(
+                    Optional.absent(),
+                    Optional.present(type),
+                    Optional.present(sort),
+                    Optional.present(2),
+                    Optional.absent(),
+                    Optional.absent()
+                )?.media
+                if (page2Media != null) {
+                    mediaList?.addAll(page2Media)
+                }
+                media.postValue(mediaList)
+            } catch (e: ApolloException) {
+                println("Error fetching top 100: $e")
+            }
+        }
+    }
+
     fun observeMedia(): LiveData<List<MediaListQuery.Medium?>?> {
         return media
+    }
+
+    fun observeSearchMediaResults(): LiveData<List<MediaListQuery.Medium?>?> {
+        return searchMediaResults
+    }
+
+    fun clearMedia() {
+        media.postValue(null)
     }
 
     fun doAnimeDetails(context: Context, anime: MediaListQuery.Medium?) {

--- a/app/src/main/java/com/android/aniviewer_kun/api/Repository.kt
+++ b/app/src/main/java/com/android/aniviewer_kun/api/Repository.kt
@@ -7,8 +7,8 @@ import com.android.aniviewer_kun.type.MediaSort
 import com.apollographql.apollo3.api.Optional
 
 class Repository(private val api: AniListApi) {
-    suspend fun getMediaByStatus(status: Optional<MediaStatus?>, type: MediaType, sort: List<MediaSort>): MediaListQuery.Page? {
-        val response = api.getApolloClient().query(MediaListQuery(status, type, sort)).execute()
+    suspend fun getMediaList(status: Optional<MediaStatus?>, type: Optional<MediaType?>, sort: Optional<List<MediaSort>>, currentPage: Optional<Int?>, perPage: Optional<Int?>, search: Optional<String?>): MediaListQuery.Page? {
+        val response = api.getApolloClient().query(MediaListQuery(status, type, sort, currentPage, perPage, search)).execute()
         return response.data?.Page
     }
 }

--- a/app/src/main/java/com/android/aniviewer_kun/ui/SearchFragment.kt
+++ b/app/src/main/java/com/android/aniviewer_kun/ui/SearchFragment.kt
@@ -1,0 +1,79 @@
+package com.android.aniviewer_kun.ui
+
+import android.content.Context
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.android.aniviewer_kun.MainViewModel
+import com.android.aniviewer_kun.MediaRowAdapter
+import com.android.aniviewer_kun.R
+import com.android.aniviewer_kun.databinding.FragmentRvBinding
+import com.android.aniviewer_kun.databinding.FragmentRvSearchBinding
+import com.android.aniviewer_kun.databinding.FragmentRvSortBinding
+import com.android.aniviewer_kun.type.MediaSort
+import com.android.aniviewer_kun.type.MediaStatus
+import com.android.aniviewer_kun.type.MediaType
+import com.apollographql.apollo3.api.Optional
+
+class SearchFragment : Fragment() {
+    private val viewModel: MainViewModel by activityViewModels()
+    private var _binding: FragmentRvSearchBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var adapter: MediaRowAdapter
+    private lateinit var recyclerView: RecyclerView
+
+    private fun initAdapter(binding: FragmentRvSearchBinding): MediaRowAdapter {
+        val adapter = MediaRowAdapter(viewModel, this)
+        recyclerView = binding.recyclerView
+        recyclerView.adapter = adapter
+        val manager = LinearLayoutManager(binding.root.context)
+        recyclerView.layoutManager = manager
+        return adapter
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentRvSearchBinding.inflate(inflater, container, false)
+        viewModel.clearMedia()
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        adapter = initAdapter(binding)
+
+        val cityAdapter = ArrayAdapter.createFromResource(
+            binding.root.context,
+            R.array.sortOptions,
+            android.R.layout.simple_spinner_item
+        )
+        cityAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+
+        binding.searchButton.setOnClickListener {
+            val text = binding.searchBar.text.toString()
+            if (text.isNotEmpty()) {
+                viewModel.searchMedia(text, 20)
+            }
+        }
+
+        viewModel.observeSearchMediaResults().observe(viewLifecycleOwner) {
+            adapter.setMedia(it)
+            adapter.submitList(it)
+            adapter.notifyDataSetChanged()
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_rv.xml
+++ b/app/src/main/res/layout/fragment_rv.xml
@@ -7,38 +7,6 @@
     android:background="#FFFFFFFF"
     android:id="@+id/airingFragment"
     android:layout_margin="8dp">
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:id="@+id/control"
-        >
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:text="@string/filterSort"
-            app:layout_constraintEnd_toStartOf="@+id/sortSpinner"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:id="@+id/filterSortText"/>
-        <Spinner
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/sortSpinner"
-            app:layout_constraintEnd_toStartOf="@id/sortImage"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            />
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/sortImage"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_rv_search.xml
+++ b/app/src/main/res/layout/fragment_rv_search.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:background="#FFFFFFFF"
+    android:id="@+id/airingFragment"
+    android:layout_margin="8dp">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:id="@+id/control"
+        >
+
+        <EditText
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:id="@+id/searchBar"
+            android:maxLines="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/searchButton"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+        <Button
+            android:id="@+id/searchButton"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:text="@string/search"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_rv_sort.xml
+++ b/app/src/main/res/layout/fragment_rv_sort.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:background="#FFFFFFFF"
+    android:id="@+id/airingFragment"
+    android:layout_margin="8dp">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:id="@+id/control"
+        >
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/filterSort"
+            app:layout_constraintEnd_toStartOf="@+id/sortSpinner"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:id="@+id/filterSortText"
+            android:layout_marginRight="10dp"/>
+        <Spinner
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/sortSpinner"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/swipeRefreshLayout"
+        >
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -9,4 +9,16 @@
             android:icon="@drawable/ic_menu_camera"
             android:title="@string/airing" />
     </group>
+    <group android:checkableBehavior="single">
+        <item
+            android:id="@+id/nav_top100"
+            android:icon="@drawable/ic_menu_camera"
+            android:title="@string/top100" />
+    </group>
+    <group android:checkableBehavior="single">
+        <item
+            android:id="@+id/nav_search"
+            android:icon="@drawable/ic_menu_camera"
+            android:title="@string/search" />
+    </group>
 </menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -9,6 +9,16 @@
         android:id="@+id/nav_airing"
         android:name="com.android.aniviewer_kun.ui.AiringFragment"
         android:label="@string/airing"
+        tools:layout="@layout/fragment_rv_sort" />
+    <fragment
+        android:id="@+id/nav_top100"
+        android:name="com.android.aniviewer_kun.ui.Top100Fragment"
+        android:label="@string/top100"
         tools:layout="@layout/fragment_rv" />
+    <fragment
+        android:id="@+id/nav_search"
+        android:name="com.android.aniviewer_kun.ui.SearchFragment"
+        android:label="@string/search"
+        tools:layout="@layout/fragment_rv_search" />
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="airing">Now Airing</string>
     <string name="menu">Menu</string>
     <string name="filterSort">Sort by:</string>
+    <string name="top100">Top 100</string>
+    <string name="search">Search</string>
 
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>


### PR DESCRIPTION
Changes:
- added search and top 100
- Added accompanying fields to the media list query
- Cleanup up the the media queries so that the ViewModel handles the optional object
- Removed ascending sort (for now) as it just displays mostly incomplete data
- Fixed bug where navdrawer would crash if switching to a previously visited page

Airing:
![airing2](https://user-images.githubusercontent.com/24766645/201544736-d7838a6f-6df4-47ef-8fb2-6c844b56e988.JPG)

Top 100: 
![top100-2](https://user-images.githubusercontent.com/24766645/201544741-ab1c5c1e-cc72-48e6-8a22-a5c75e286894.JPG)

Search:
![search2](https://user-images.githubusercontent.com/24766645/201544747-1fef5008-31f1-4a7e-a720-8432d9f2705a.JPG)
